### PR TITLE
Rack Updates

### DIFF
--- a/Source/GearItem.h
+++ b/Source/GearItem.h
@@ -136,6 +136,8 @@ public:
     juce::String categoryString;
     juce::StringArray tags;
     juce::Image image;
+    juce::String faceplateImagePath;
+    juce::Image faceplateImage;
     juce::Array<GearControl> controls;
 
     bool loadImage();

--- a/Source/GearLibrary.h
+++ b/Source/GearLibrary.h
@@ -73,10 +73,43 @@ public:
     // Helper method to construct a full URL from a relative path
     static juce::String getFullUrl(const juce::String &relativePath)
     {
+        DBG("GearLibrary::getFullUrl called with path: " + relativePath);
+
+        // If already a full URL, return as is
         if (relativePath.startsWith("http"))
             return relativePath;
 
-        return RemoteResources::BASE_URL + relativePath;
+        // If this is an absolute path on the filesystem, return as is
+        if (relativePath.startsWith("/"))
+            return relativePath;
+
+        // Handle the case where we might need to add assets/ or units/ prefix
+        juce::String result;
+
+        if (relativePath.startsWith("assets/") || relativePath.startsWith("units/"))
+        {
+            // Path already has the correct folder prefix
+            result = RemoteResources::BASE_URL + relativePath;
+        }
+        else if (relativePath.endsWith(".json"))
+        {
+            // Likely a schema file - add units/ prefix if needed
+            result = RemoteResources::BASE_URL + RemoteResources::SCHEMAS_PATH + relativePath;
+        }
+        else if (relativePath.endsWith(".jpg") || relativePath.endsWith(".png") ||
+                 relativePath.endsWith(".jpeg") || relativePath.endsWith(".gif"))
+        {
+            // Likely an image file - add assets/ prefix if needed
+            result = RemoteResources::BASE_URL + RemoteResources::ASSETS_PATH + relativePath;
+        }
+        else
+        {
+            // Default case - just append to base URL
+            result = RemoteResources::BASE_URL + relativePath;
+        }
+
+        DBG("Full URL constructed: " + result);
+        return result;
     }
 
 private:

--- a/Source/Rack.cpp
+++ b/Source/Rack.cpp
@@ -5,25 +5,25 @@ Rack::Rack()
 {
     DBG("Rack constructor");
     setComponentID("Rack");
-    
+
     // Create viewport and container
     rackViewport = std::make_unique<juce::Viewport>();
     rackContainer = std::make_unique<RackContainer>();
     rackViewport->setViewedComponent(rackContainer.get(), false); // false = don't delete when viewport is deleted
     addAndMakeVisible(rackViewport.get());
-    
+
     // Set up the container
     rackContainer->rack = this;
-    
+
     // Create rack slots
     DBG("Creating " + juce::String(numSlots) + " rack slots");
     for (int i = 0; i < numSlots; ++i)
     {
-        RackSlot* newSlot = new RackSlot(i);
+        RackSlot *newSlot = new RackSlot(i);
         slots.add(newSlot);
         rackContainer->addAndMakeVisible(newSlot);
     }
-    
+
     // Set up this component as a drag-and-drop target
     setInterceptsMouseClicks(true, true);
 }
@@ -34,61 +34,108 @@ Rack::~Rack()
     // unique_ptr members will be automatically deleted
 }
 
-void Rack::paint(juce::Graphics& g)
+void Rack::paint(juce::Graphics &g)
 {
     g.fillAll(juce::Colours::black);
+}
+
+int Rack::getSlotHeight(int slotIndex) const
+{
+    if (slotIndex < 0 || slotIndex >= slots.size())
+        return getDefaultSlotHeight();
+
+    RackSlot *slot = slots[slotIndex];
+    if (slot == nullptr)
+        return getDefaultSlotHeight();
+
+    // If the slot has a gear item with a faceplate image, use the image's height plus padding
+    GearItem *item = slot->getGearItem();
+    if (item != nullptr && item->faceplateImage.isValid())
+    {
+        // Calculate a reasonable height based on the faceplate image
+        // Use aspect ratio of the image, but constrained to reasonable bounds
+        int imageHeight = item->faceplateImage.getHeight();
+        int imageWidth = item->faceplateImage.getWidth();
+
+        if (imageHeight > 0 && imageWidth > 0)
+        {
+            // Calculate what the height would be if the width matched the slot width
+            // Add extra padding for controls and slot UI elements
+            int effectiveSlotWidth = rackContainer->getWidth() - (2 * slotSpacing);
+            int scaledHeight = (imageHeight * effectiveSlotWidth) / imageWidth;
+
+            // Add padding for slot UI elements (buttons, labels, etc.)
+            int paddedHeight = scaledHeight + 40; // 20px padding top and bottom
+
+            // Constrain to reasonable bounds
+            return juce::jlimit(100, 400, paddedHeight);
+        }
+    }
+
+    // Default height if no special considerations apply
+    return getDefaultSlotHeight();
 }
 
 void Rack::resized()
 {
     DBG("Rack::resized");
-    
+
     // Size the viewport to fill our area
     auto area = getLocalBounds();
     rackViewport->setBounds(area);
-    
+
     // Get the available width from the viewport
     const int availableWidth = rackViewport->getWidth();
-    
-    // Size the container to fit all slots with spacing
-    const int containerHeight = numSlots * (slotHeight + slotSpacing) + slotSpacing;
-    const int containerWidth = availableWidth; // Use full viewport width
-    rackContainer->setSize(containerWidth, containerHeight);
-    
-    // Calculate the slot width based on container width minus margins
-    const int effectiveSlotWidth = containerWidth - (2 * slotSpacing);
-    
-    // Position the slots within the container
+
+    // Calculate total height needed for all slots with their variable heights
+    int totalHeight = slotSpacing; // Start with top spacing
     for (int i = 0; i < slots.size(); ++i)
     {
-        auto* slot = slots[i];
+        totalHeight += getSlotHeight(i) + slotSpacing;
+    }
+
+    // Size the container to fit all slots with spacing
+    const int containerWidth = availableWidth; // Use full viewport width
+    rackContainer->setSize(containerWidth, totalHeight);
+
+    // Calculate the slot width based on container width minus margins
+    const int effectiveSlotWidth = containerWidth - (2 * slotSpacing);
+
+    // Position the slots within the container
+    int currentY = slotSpacing;
+    for (int i = 0; i < slots.size(); ++i)
+    {
+        auto *slot = slots[i];
+        int slotHeight = getSlotHeight(i);
+
         slot->setBounds(
             slotSpacing,
-            slotSpacing + i * (slotHeight + slotSpacing),
+            currentY,
             effectiveSlotWidth,
-            slotHeight
-        );
+            slotHeight);
+
+        currentY += slotHeight + slotSpacing;
     }
-    
+
     DBG("Rack resized: viewport=" + rackViewport->getBounds().toString() +
         ", container=" + rackContainer->getBounds().toString());
 }
 
-bool Rack::isInterestedInDragSource(const juce::DragAndDropTarget::SourceDetails& dragSourceDetails)
+bool Rack::isInterestedInDragSource(const juce::DragAndDropTarget::SourceDetails &dragSourceDetails)
 {
     // Accept drops from DraggableListBox (GearLibrary) or other RackSlots
-    auto* sourceComp = dragSourceDetails.sourceComponent.get();
-    
+    auto *sourceComp = dragSourceDetails.sourceComponent.get();
+
     // Check for drags from the legacy list box
-    if (sourceComp && (sourceComp->getComponentID() == "DraggableListBox" || 
-                     sourceComp->getComponentID() == "GearListBox" ||
-                     dynamic_cast<RackSlot*>(sourceComp) != nullptr))
+    if (sourceComp && (sourceComp->getComponentID() == "DraggableListBox" ||
+                       sourceComp->getComponentID() == "GearListBox" ||
+                       dynamic_cast<RackSlot *>(sourceComp) != nullptr))
     {
         return true;
     }
-    
+
     // Check for drags from the TreeView
-    if (sourceComp && dynamic_cast<juce::TreeView*>(sourceComp) != nullptr)
+    if (sourceComp && dynamic_cast<juce::TreeView *>(sourceComp) != nullptr)
     {
         if (dragSourceDetails.description.isString())
         {
@@ -99,64 +146,67 @@ bool Rack::isInterestedInDragSource(const juce::DragAndDropTarget::SourceDetails
             }
         }
     }
-    
+
     return false;
 }
 
-void Rack::itemDragEnter(const juce::DragAndDropTarget::SourceDetails& /*dragSourceDetails*/)
+void Rack::itemDragEnter(const juce::DragAndDropTarget::SourceDetails & /*dragSourceDetails*/)
 {
     // Nothing to do here
 }
 
-void Rack::itemDragMove(const juce::DragAndDropTarget::SourceDetails& details)
+void Rack::itemDragMove(const juce::DragAndDropTarget::SourceDetails &details)
 {
     // This is only used for dragging from GearLibrary now, not for reordering
-    RackSlot* nearestSlot = findNearestSlot(details.localPosition);
-    
+    RackSlot *nearestSlot = findNearestSlot(details.localPosition);
+
     // Highlight the nearest slot
-    for (auto* slot : slots)
+    for (auto *slot : slots)
     {
         slot->setHighlighted(slot == nearestSlot);
     }
 }
 
-void Rack::itemDragExit(const juce::DragAndDropTarget::SourceDetails& /*dragSourceDetails*/)
+void Rack::itemDragExit(const juce::DragAndDropTarget::SourceDetails & /*dragSourceDetails*/)
 {
     // Clear all highlights
-    for (auto* slot : slots)
+    for (auto *slot : slots)
     {
         slot->setHighlighted(false);
     }
 }
 
-void Rack::itemDropped(const juce::DragAndDropTarget::SourceDetails& details)
+void Rack::itemDropped(const juce::DragAndDropTarget::SourceDetails &details)
 {
     DBG("Rack::itemDropped");
-    
+
     // Find the nearest slot to the drop position
-    RackSlot* targetSlot = findNearestSlot(details.localPosition);
+    RackSlot *targetSlot = findNearestSlot(details.localPosition);
     if (targetSlot == nullptr)
     {
         DBG("No target slot found for drop position");
         return;
     }
-    
+
     // Clear highlights
-    for (auto* slot : slots)
+    for (auto *slot : slots)
     {
         slot->setHighlighted(false);
     }
-    
+
     // Handle drops from GearLibrary (legacy list box)
     if (details.description.isInt() && gearLibrary != nullptr)
     {
         int gearIndex = static_cast<int>(details.description);
-        GearItem* item = gearLibrary->getGearItem(gearIndex);
-        
+        GearItem *item = gearLibrary->getGearItem(gearIndex);
+
         if (item != nullptr)
         {
             DBG("Adding gear item from listbox: " + item->name + " to slot " + juce::String(targetSlot->getIndex()));
             targetSlot->setGearItem(item);
+
+            // Fetch schema for this item
+            fetchSchemaForGearItem(item);
         }
     }
     // Handle drops from TreeView
@@ -168,33 +218,36 @@ void Rack::itemDropped(const juce::DragAndDropTarget::SourceDetails& details)
             // Parse the gear index from the drag descriptor
             juce::StringArray parts;
             parts.addTokens(desc, ":", "");
-            
+
             if (parts.size() >= 3)
             {
                 int gearIndex = parts[1].getIntValue();
-                GearItem* item = gearLibrary->getGearItem(gearIndex);
-                
+                GearItem *item = gearLibrary->getGearItem(gearIndex);
+
                 if (item != nullptr)
                 {
                     DBG("Adding gear item from TreeView: " + item->name + " to slot " + juce::String(targetSlot->getIndex()));
                     targetSlot->setGearItem(item);
+
+                    // Fetch schema for this item
+                    fetchSchemaForGearItem(item);
                 }
             }
         }
     }
     // Handle drops from other RackSlots (rearranging)
-    else if (auto* sourceSlot = dynamic_cast<RackSlot*>(details.sourceComponent.get()))
+    else if (auto *sourceSlot = dynamic_cast<RackSlot *>(details.sourceComponent.get()))
     {
         if (sourceSlot != targetSlot && sourceSlot->getGearItem() != nullptr)
         {
             // Swap the items between slots
-            GearItem* sourceItem = sourceSlot->getGearItem();
-            GearItem* targetItem = targetSlot->getGearItem();
-            
+            GearItem *sourceItem = sourceSlot->getGearItem();
+            GearItem *targetItem = targetSlot->getGearItem();
+
             sourceSlot->setGearItem(targetItem);
             targetSlot->setGearItem(sourceItem);
-            
-            DBG("Swapped gear items between slots " + juce::String(sourceSlot->getIndex()) + 
+
+            DBG("Swapped gear items between slots " + juce::String(sourceSlot->getIndex()) +
                 " and " + juce::String(targetSlot->getIndex()));
         }
     }
@@ -203,9 +256,9 @@ void Rack::itemDropped(const juce::DragAndDropTarget::SourceDetails& details)
 void Rack::rearrangeGearAsSortableList(int sourceSlotIndex, int targetSlotIndex)
 {
     DBG("===============================================");
-    DBG("Rack::rearrangeGearAsSortableList - sourceIndex: " + juce::String(sourceSlotIndex) + 
+    DBG("Rack::rearrangeGearAsSortableList - sourceIndex: " + juce::String(sourceSlotIndex) +
         ", targetIndex: " + juce::String(targetSlotIndex));
-    
+
     // Validate indices
     if (sourceSlotIndex < 0 || sourceSlotIndex >= slots.size() ||
         targetSlotIndex < 0 || targetSlotIndex >= slots.size() ||
@@ -214,83 +267,443 @@ void Rack::rearrangeGearAsSortableList(int sourceSlotIndex, int targetSlotIndex)
         DBG("Invalid source or target index, or they are the same. Aborting rearrangement.");
         return;
     }
-    
+
     // Get pointers to the source and target slots
-    RackSlot* sourceSlot = slots[sourceSlotIndex];
-    RackSlot* targetSlot = slots[targetSlotIndex];
-    
+    RackSlot *sourceSlot = slots[sourceSlotIndex];
+    RackSlot *targetSlot = slots[targetSlotIndex];
+
     if (sourceSlot == nullptr || targetSlot == nullptr)
     {
         DBG("Source or target slot is null. Aborting rearrangement.");
         return;
     }
-    
+
     // Get the gear items from both slots
-    GearItem* sourceGearItem = sourceSlot->getGearItem();
-    GearItem* targetGearItem = targetSlot->getGearItem();
-    
+    GearItem *sourceGearItem = sourceSlot->getGearItem();
+    GearItem *targetGearItem = targetSlot->getGearItem();
+
     if (sourceGearItem == nullptr)
     {
         DBG("Source gear item is null. Cannot move an empty slot. Aborting rearrangement.");
         return;
     }
-    
+
     // Simply swap the two slots
-    DBG("Swapping gear items between slot " + juce::String(sourceSlotIndex) + 
+    DBG("Swapping gear items between slot " + juce::String(sourceSlotIndex) +
         " and slot " + juce::String(targetSlotIndex));
-    
+
     // First clear both slots
     sourceSlot->clearGearItem();
     targetSlot->clearGearItem();
-    
+
     // Then set the items in their new positions
     targetSlot->setGearItem(sourceGearItem);
-    
+
     // If the target slot had an item, move it to the source slot
     if (targetGearItem != nullptr)
     {
         sourceSlot->setGearItem(targetGearItem);
     }
-    
+
     // Update the rack view
     rackContainer->resized();
-    
+
     DBG("Gear items successfully swapped.");
     DBG("===============================================");
 }
 
-RackSlot* Rack::findNearestSlot(const juce::Point<int>& position)
+RackSlot *Rack::findNearestSlot(const juce::Point<int> &position)
 {
     // This method is kept for compatibility with drops from GearLibrary
     // but we've simplified it since we're not using it for reordering
-    
+
     // Convert global position to container coordinates
     auto containerPos = rackContainer->getLocalPoint(this, position);
-    
+
     // First check for a direct hit
-    for (auto* slot : slots)
+    for (auto *slot : slots)
     {
         if (slot->getBounds().contains(containerPos))
         {
             return slot;
         }
     }
-    
+
     // If no direct hit, find the closest slot
-    RackSlot* bestSlot = nullptr;
+    RackSlot *bestSlot = nullptr;
     int bestDistance = std::numeric_limits<int>::max();
-    
-    for (auto* slot : slots)
+
+    for (auto *slot : slots)
     {
         juce::Rectangle<int> slotBounds = slot->getBounds();
         int distance = slotBounds.getCentre().getDistanceFrom(containerPos);
-        
+
         if (distance < bestDistance)
         {
             bestDistance = distance;
             bestSlot = slot;
         }
     }
-    
+
     return bestSlot;
-} 
+}
+
+// New method to fetch schema for a gear item
+void Rack::fetchSchemaForGearItem(GearItem *item)
+{
+    if (item == nullptr || item->schemaPath.isEmpty())
+    {
+        DBG("Cannot fetch schema: item is null or schema path is empty");
+        return;
+    }
+
+    DBG("Fetching schema for " + item->name + " from " + item->schemaPath);
+
+    // Construct the full URL if it's a relative path
+    juce::String fullUrl = item->schemaPath;
+    if (!fullUrl.startsWith("http"))
+    {
+        fullUrl = GearLibrary::getFullUrl(fullUrl);
+    }
+
+    DBG("Full schema URL: " + fullUrl);
+
+    // Use JUCE's URL class to fetch the schema asynchronously
+    juce::URL schemaUrl(fullUrl);
+
+    // Create a new thread to download the schema asynchronously
+    struct SchemaDownloader : public juce::Thread
+    {
+        SchemaDownloader(juce::URL urlToUse, GearItem *itemToUpdate, Rack *rackToNotify)
+            : juce::Thread("Schema Downloader"),
+              url(urlToUse), item(itemToUpdate), rack(rackToNotify)
+        {
+            startThread();
+        }
+
+        ~SchemaDownloader() override
+        {
+            stopThread(2000);
+        }
+
+        void run() override
+        {
+            DBG("SchemaDownloader thread started for " + item->name);
+
+            // Download the schema data
+            schemaData = url.readEntireTextStream(false);
+
+            if (threadShouldExit())
+                return;
+
+            success = schemaData.isNotEmpty();
+
+            // Need to get back on the message thread to update the UI
+            juce::MessageManager::callAsync([this]()
+                                            {
+                if (success)
+                {
+                    DBG("Successfully downloaded schema for " + item->name);
+                    rack->parseSchema(schemaData, item);
+                }
+                else
+                {
+                    DBG("Failed to download schema for " + item->name);
+                }
+                delete this; });
+        }
+
+        juce::URL url;
+        GearItem *item;
+        Rack *rack;
+        juce::String schemaData;
+        bool success = false;
+    };
+
+    // Create and start the download thread (it will delete itself when done)
+    new SchemaDownloader(schemaUrl, item, this);
+}
+
+// Method to parse the schema data
+void Rack::parseSchema(const juce::String &schemaData, GearItem *item)
+{
+    if (schemaData.isEmpty() || item == nullptr)
+    {
+        DBG("Cannot parse schema: data is empty or item is null");
+        return;
+    }
+
+    DBG("Parsing schema for " + item->name);
+    DBG("Schema data: " + schemaData.substring(0, 500) + "..."); // Print first part of schema for debugging
+
+    // Parse the JSON schema
+    juce::var schemaJson = juce::JSON::parse(schemaData);
+
+    if (!schemaJson.isObject())
+    {
+        DBG("Schema parsing failed: not a valid JSON object");
+        return;
+    }
+
+    // Extract schema information
+    auto *schemaObj = schemaJson.getDynamicObject();
+    if (schemaObj == nullptr)
+    {
+        DBG("Schema parsing failed: couldn't get dynamic object");
+        return;
+    }
+
+    // Debug all available properties in the schema
+    DBG("Schema contains the following properties:");
+    for (auto &prop : schemaObj->getProperties())
+    {
+        DBG(" - " + prop.name.toString());
+    }
+
+    // Check for different possible property names for the faceplate image
+    bool foundFaceplate = false;
+    juce::String faceplateImagePath;
+
+    // List of possible property names for the faceplate image
+    const std::vector<juce::String> faceplateProperties = {
+        "faceplateImage", "faceplate", "panelImage", "panel", "frontPanel",
+        "image", "fullImage", "uiImage", "mainImage"};
+
+    // Try each possible property name
+    for (const auto &propName : faceplateProperties)
+    {
+        if (schemaJson.hasProperty(propName))
+        {
+            faceplateImagePath = schemaJson.getProperty(propName, "").toString();
+            if (faceplateImagePath.isNotEmpty())
+            {
+                DBG("Found faceplate image with property name '" + propName + "': " + faceplateImagePath);
+                foundFaceplate = true;
+
+                // Store the path in the gear item
+                item->faceplateImagePath = faceplateImagePath;
+
+                // Fetch the faceplate image
+                fetchFaceplateImage(item);
+                break;
+            }
+        }
+    }
+
+    if (!foundFaceplate)
+    {
+        DBG("No faceplate image found in schema. Using thumbnail image instead.");
+    }
+
+    // Update controls if available
+    if (schemaJson.hasProperty("controls") && schemaJson["controls"].isArray())
+    {
+        item->controls.clear();
+
+        auto controlsArray = schemaJson["controls"].getArray();
+        for (auto &controlVar : *controlsArray)
+        {
+            if (!controlVar.isObject())
+                continue;
+
+            // Get control type
+            GearControl::Type controlType = GearControl::Type::Knob;
+            juce::String controlTypeStr = controlVar.getProperty("type", "Knob");
+            if (controlTypeStr == "Button")
+                controlType = GearControl::Type::Button;
+            else if (controlTypeStr == "Fader")
+                controlType = GearControl::Type::Fader;
+
+            // Get control name
+            juce::String controlName = controlVar.getProperty("name", "");
+
+            // Get position
+            juce::Rectangle<float> position;
+            if (controlVar.hasProperty("position") && controlVar["position"].isObject())
+            {
+                position.setX(controlVar["position"].getProperty("x", 0.0f));
+                position.setY(controlVar["position"].getProperty("y", 0.0f));
+                position.setWidth(controlVar["position"].getProperty("width", 0.0f));
+                position.setHeight(controlVar["position"].getProperty("height", 0.0f));
+            }
+
+            // Create control and add to array
+            GearControl control(controlType, controlName, position);
+            control.value = controlVar.getProperty("value", 0.0f);
+            item->controls.add(control);
+        }
+
+        DBG("Added " + juce::String(item->controls.size()) + " controls to " + item->name);
+    }
+
+    // Notify that the schema has been loaded
+    DBG("Schema successfully parsed for " + item->name);
+}
+
+// New method to fetch the faceplate image
+void Rack::fetchFaceplateImage(GearItem *item)
+{
+    if (item == nullptr || item->faceplateImagePath.isEmpty())
+    {
+        DBG("Cannot fetch faceplate image: item is null or faceplate path is empty");
+        return;
+    }
+
+    DBG("Fetching faceplate image for " + item->name + " from " + item->faceplateImagePath);
+
+    // Construct the full URL if it's a relative path
+    juce::String fullUrl = item->faceplateImagePath;
+    if (!fullUrl.startsWith("http"))
+    {
+        // Check if the path is already a full path or needs the base URL
+        if (fullUrl.startsWith("assets/") || !fullUrl.contains("/"))
+        {
+            fullUrl = GearLibrary::getFullUrl(fullUrl);
+        }
+    }
+
+    DBG("Full faceplate image URL: " + fullUrl);
+
+    // Use JUCE's URL class to fetch the image asynchronously
+    juce::URL imageUrl(fullUrl);
+
+    // Direct image loading isn't available in this version of JUCE, so skip straight to async
+    DBG("Starting async download for faceplate image...");
+
+    // Create a new thread to download the image asynchronously
+    struct FaceplateImageDownloader : public juce::Thread
+    {
+        FaceplateImageDownloader(juce::URL urlToUse, GearItem *itemToUpdate, Rack *parentRack)
+            : juce::Thread("Faceplate Image Downloader"),
+              url(urlToUse), item(itemToUpdate), rack(parentRack)
+        {
+            startThread();
+        }
+
+        ~FaceplateImageDownloader() override
+        {
+            stopThread(2000);
+        }
+
+        void run() override
+        {
+            DBG("FaceplateImageDownloader thread started for " + item->name);
+
+            // Try to download using the simple API - this is for older JUCE versions
+            std::unique_ptr<juce::InputStream> inputStream = url.createInputStream(false);
+
+            if (inputStream == nullptr || threadShouldExit())
+            {
+                DBG("Failed to create input stream for faceplate image: " + url.toString(true));
+
+                // Clean up on the message thread
+                juce::MessageManager::callAsync([this]()
+                                                { delete this; });
+
+                return;
+            }
+
+            // Try to determine image format
+            juce::String urlStr = url.toString(true).toLowerCase();
+            juce::ImageFileFormat *format = nullptr;
+
+            if (urlStr.contains(".jpg") || urlStr.contains(".jpeg"))
+                format = new juce::JPEGImageFormat();
+            else if (urlStr.contains(".png"))
+                format = new juce::PNGImageFormat();
+            else if (urlStr.contains(".gif"))
+                format = new juce::GIFImageFormat();
+
+            // Load the image from the input stream
+            juce::Image downloadedImage;
+
+            if (format != nullptr)
+            {
+                // Use specific format if we could determine it
+                downloadedImage = format->decodeImage(*inputStream);
+                delete format;
+            }
+            else
+            {
+                // Otherwise use the generic loader
+                downloadedImage = juce::ImageFileFormat::loadFrom(*inputStream);
+            }
+
+            if (downloadedImage.isValid())
+            {
+                DBG("Successfully loaded image with dimensions: " +
+                    juce::String(downloadedImage.getWidth()) + "x" +
+                    juce::String(downloadedImage.getHeight()));
+
+                // Need to get back on the message thread to update the UI
+                juce::MessageManager::callAsync([this, downloadedImage]()
+                                                {
+                    DBG("Successfully downloaded faceplate image for " + item->name);
+                    
+                    // Update the item's faceplate image
+                    item->faceplateImage = downloadedImage;
+                    
+                    // Notify any slots that have this item to repaint
+                    if (rack != nullptr)
+                    {
+                        for (int i = 0; i < rack->getNumSlots(); ++i)
+                        {
+                            RackSlot *slot = rack->getSlot(i);
+                            if (slot && slot->getGearItem() == item)
+                            {
+                                DBG("Repainting slot " + juce::String(i) + " with faceplate image");
+                                slot->repaint();
+                            }
+                        }
+                        
+                        // Trigger a re-layout to adjust slot heights for the new image
+                        rack->resized();
+                    }
+                    
+                    delete this; });
+            }
+            else
+            {
+                // Image loading failed, clean up
+                juce::MessageManager::callAsync([this]()
+                                                {
+                    DBG("Failed to load faceplate image for " + item->name);
+                    
+                    // Create a placeholder image instead
+                    juce::Image placeholderImage(juce::Image::RGB, 200, 100, true);
+                    juce::Graphics g(placeholderImage);
+                    g.fillAll(juce::Colours::darkgrey);
+                    g.setColour(juce::Colours::white);
+                    g.drawText("Faceplate Unavailable", placeholderImage.getBounds(), juce::Justification::centred, true);
+                    
+                    // Set as faceplate image
+                    item->faceplateImage = placeholderImage;
+                    
+                    // Repaint any slots with this item
+                    if (rack != nullptr)
+                    {
+                        for (int i = 0; i < rack->getNumSlots(); ++i)
+                        {
+                            RackSlot *slot = rack->getSlot(i);
+                            if (slot && slot->getGearItem() == item)
+                            {
+                                slot->repaint();
+                            }
+                        }
+                        
+                        // Trigger a re-layout to adjust slot heights for the placeholder image
+                        rack->resized();
+                    }
+                    
+                    delete this; });
+            }
+        }
+
+        juce::URL url;
+        GearItem *item;
+        Rack *rack;
+    };
+
+    // Create and start the download thread (it will delete itself when done)
+    new FaceplateImageDownloader(imageUrl, item, this);
+}

--- a/Source/Rack.h
+++ b/Source/Rack.h
@@ -12,50 +12,61 @@ public:
     Rack();
     ~Rack() override;
 
-    void paint(juce::Graphics& g) override;
+    void paint(juce::Graphics &g) override;
     void resized() override;
-    
+
     // DragAndDropTarget methods
-    bool isInterestedInDragSource(const juce::DragAndDropTarget::SourceDetails& dragSourceDetails) override;
-    void itemDragEnter(const juce::DragAndDropTarget::SourceDetails& dragSourceDetails) override;
-    void itemDragMove(const juce::DragAndDropTarget::SourceDetails& dragSourceDetails) override;
-    void itemDragExit(const juce::DragAndDropTarget::SourceDetails& dragSourceDetails) override;
-    void itemDropped(const juce::DragAndDropTarget::SourceDetails& dragSourceDetails) override;
-    
+    bool isInterestedInDragSource(const juce::DragAndDropTarget::SourceDetails &dragSourceDetails) override;
+    void itemDragEnter(const juce::DragAndDropTarget::SourceDetails &dragSourceDetails) override;
+    void itemDragMove(const juce::DragAndDropTarget::SourceDetails &dragSourceDetails) override;
+    void itemDragExit(const juce::DragAndDropTarget::SourceDetails &dragSourceDetails) override;
+    void itemDropped(const juce::DragAndDropTarget::SourceDetails &dragSourceDetails) override;
+
     // Swap items between two slots (for button-based reordering)
     void rearrangeGearAsSortableList(int sourceSlotIndex, int targetSlotIndex);
-    
+
     // Find the nearest slot to a position (for drops from library)
-    RackSlot* findNearestSlot(const juce::Point<int>& position);
-    
+    RackSlot *findNearestSlot(const juce::Point<int> &position);
+
     // Get the number of slots
     int getNumSlots() const { return slots.size(); }
-    
+
+    // Get a specific slot by index
+    RackSlot *getSlot(int index) const { return (index >= 0 && index < slots.size()) ? slots[index] : nullptr; }
+
     // Set the gear library reference
-    void setGearLibrary(GearLibrary* library) { gearLibrary = library; }
-    
+    void setGearLibrary(GearLibrary *library) { gearLibrary = library; }
+
+    // Schema management
+    void fetchSchemaForGearItem(GearItem *item);
+    void parseSchema(const juce::String &schemaData, GearItem *item);
+    void fetchFaceplateImage(GearItem *item);
+
     // Internal container class for rack slots
     class RackContainer : public juce::Component
     {
     public:
         RackContainer() { setComponentID("RackContainer"); }
-        void paint(juce::Graphics& g) override { g.fillAll(juce::Colours::black); }
-        Rack* rack = nullptr;
+        void paint(juce::Graphics &g) override { g.fillAll(juce::Colours::black); }
+        Rack *rack = nullptr;
     };
-    
+
 private:
     // Configuration
     int numSlots = 16;
-    int slotHeight = 150;
     int slotSpacing = 10;
-    
+
     // UI Components
     std::unique_ptr<juce::Viewport> rackViewport;
     std::unique_ptr<RackContainer> rackContainer;
     juce::OwnedArray<RackSlot> slots;
-    
+
     // Reference to the gear library (for drag and drop)
-    GearLibrary* gearLibrary = nullptr;
-    
+    GearLibrary *gearLibrary = nullptr;
+
+    // Helper method to get slot height based on the contained item
+    int getSlotHeight(int slotIndex) const;
+    int getDefaultSlotHeight() const { return 150; } // Default height if not overridden
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Rack)
-}; 
+};

--- a/Source/RackSlot.cpp
+++ b/Source/RackSlot.cpp
@@ -7,53 +7,57 @@ RackSlot::RackSlot(int slotIndex)
 {
     setComponentID("RackSlot_" + juce::String(index));
     setInterceptsMouseClicks(true, true);
-    
+
     // Create arrow buttons for moving items up and down
-    auto createArrowPath = [](bool isUpArrow) {
+    auto createArrowPath = [](bool isUpArrow)
+    {
         juce::Path arrowPath;
-        if (isUpArrow) {
+        if (isUpArrow)
+        {
             // Up arrow
             arrowPath.addTriangle(10.0f, 2.0f, 2.0f, 18.0f, 18.0f, 18.0f);
-        } else {
+        }
+        else
+        {
             // Down arrow
             arrowPath.addTriangle(10.0f, 18.0f, 2.0f, 2.0f, 18.0f, 2.0f);
         }
         return arrowPath;
     };
-    
+
     // Create drawable objects for the buttons
     auto normalUpArrow = std::make_unique<juce::DrawablePath>();
     normalUpArrow->setPath(createArrowPath(true));
     normalUpArrow->setFill(juce::Colours::white.withAlpha(0.8f));
-    
+
     auto overUpArrow = std::make_unique<juce::DrawablePath>();
     overUpArrow->setPath(createArrowPath(true));
     overUpArrow->setFill(juce::Colours::white);
-    
+
     auto normalDownArrow = std::make_unique<juce::DrawablePath>();
     normalDownArrow->setPath(createArrowPath(false));
     normalDownArrow->setFill(juce::Colours::white.withAlpha(0.8f));
-    
+
     auto overDownArrow = std::make_unique<juce::DrawablePath>();
     overDownArrow->setPath(createArrowPath(false));
     overDownArrow->setFill(juce::Colours::white);
-    
+
     // Create the buttons
     upButton = std::make_unique<juce::DrawableButton>("UpButton", juce::DrawableButton::ButtonStyle::ImageFitted);
     upButton->setImages(normalUpArrow.get(), overUpArrow.get());
     upButton->setTooltip("Move item up");
     upButton->addListener(this);
     addAndMakeVisible(upButton.get());
-    
+
     downButton = std::make_unique<juce::DrawableButton>("DownButton", juce::DrawableButton::ButtonStyle::ImageFitted);
     downButton->setImages(normalDownArrow.get(), overDownArrow.get());
     downButton->setTooltip("Move item down");
     downButton->addListener(this);
     addAndMakeVisible(downButton.get());
-    
+
     // Initial button state
     updateButtonStates();
-    
+
     DBG("Created RackSlot with index " + juce::String(index));
 }
 
@@ -66,44 +70,85 @@ RackSlot::~RackSlot()
         downButton->removeListener(this);
 }
 
-void RackSlot::paint(juce::Graphics& g)
+void RackSlot::paint(juce::Graphics &g)
 {
     // Draw background
     juce::Colour bgColor = isAvailable() ? juce::Colours::darkgrey : juce::Colours::darkslategrey;
     g.fillAll(bgColor);
-    
+
     // Draw border (highlighted if being dragged over)
     juce::Colour borderColor = highlighted ? juce::Colours::orange : juce::Colours::grey;
     g.setColour(borderColor);
     g.drawRect(getLocalBounds(), 2);
-    
+
     // Draw slot number
     g.setColour(juce::Colours::white);
-    g.drawText(juce::String(index), getLocalBounds().reduced(5, 5).removeFromTop(20), 
+    g.drawText(juce::String(index), getLocalBounds().reduced(5, 5).removeFromTop(20),
                juce::Justification::topLeft, true);
-    
-    // If we have a gear item, draw its name and image
+
+    // If we have a gear item, draw its details and image
     if (!isAvailable() && gearItem != nullptr)
     {
-        // Draw name
-        g.setFont(16.0f);
-        g.setColour(juce::Colours::white);
-        juce::Rectangle<int> nameArea = getLocalBounds().reduced(10, 10);
-        g.drawText(gearItem->name, nameArea, juce::Justification::centred, true);
-        
-        // Draw manufacturer below name
-        g.setFont(12.0f);
-        g.setColour(juce::Colours::lightgrey);
-        juce::Rectangle<int> mfgArea = nameArea.translated(0, 20);
-        g.drawText(gearItem->manufacturer, mfgArea, juce::Justification::centred, true);
-        
-        // Draw image if available
-        if (gearItem->image.isValid())
+        // Debug info about the gear item
+        DBG("RackSlot::paint - Slot " + juce::String(index) + " painting gear item: " + gearItem->name);
+        DBG("  - Has faceplate image: " + juce::String(gearItem->faceplateImage.isValid() ? "YES" : "NO"));
+        if (gearItem->faceplateImage.isValid())
         {
-            juce::Rectangle<int> imageArea = getLocalBounds().reduced(20);
-            g.drawImageWithin(gearItem->image, imageArea.getX(), imageArea.getY() + 40, 
-                             imageArea.getWidth(), imageArea.getHeight() - 40, 
-                             juce::RectanglePlacement::centred);
+            DBG("  - Faceplate dimensions: " +
+                juce::String(gearItem->faceplateImage.getWidth()) + "x" +
+                juce::String(gearItem->faceplateImage.getHeight()));
+        }
+        DBG("  - Has thumbnail image: " + juce::String(gearItem->image.isValid() ? "YES" : "NO"));
+
+        // Check if we have a faceplate image
+        bool hasFaceplate = gearItem->faceplateImage.isValid();
+
+        if (hasFaceplate)
+        {
+            DBG("Drawing faceplate image for " + gearItem->name + " in slot " + juce::String(index));
+
+            // If we have a faceplate image, use it instead of the default rendering
+            juce::Rectangle<int> faceplateArea = getLocalBounds().reduced(10);
+
+            // Draw name above the faceplate (for better identification)
+            g.setFont(12.0f);
+            g.setColour(juce::Colours::white);
+            juce::Rectangle<int> nameArea = faceplateArea.removeFromTop(20);
+            g.drawText(gearItem->name, nameArea, juce::Justification::centred, true);
+
+            // Draw the faceplate image
+            g.drawImageWithin(gearItem->faceplateImage,
+                              faceplateArea.getX(), faceplateArea.getY(),
+                              faceplateArea.getWidth(), faceplateArea.getHeight(),
+                              juce::RectanglePlacement::centred | juce::RectanglePlacement::onlyReduceInSize);
+        }
+        else
+        {
+            DBG("No faceplate image available for " + gearItem->name + " in slot " + juce::String(index) + ", using standard display");
+
+            // No faceplate, use the original rendering with name, manufacturer and thumbnail
+
+            // Draw name
+            g.setFont(16.0f);
+            g.setColour(juce::Colours::white);
+            juce::Rectangle<int> nameArea = getLocalBounds().reduced(10, 10);
+            g.drawText(gearItem->name, nameArea, juce::Justification::centred, true);
+
+            // Draw manufacturer below name
+            g.setFont(12.0f);
+            g.setColour(juce::Colours::lightgrey);
+            juce::Rectangle<int> mfgArea = nameArea.translated(0, 20);
+            g.drawText(gearItem->manufacturer, mfgArea, juce::Justification::centred, true);
+
+            // Draw thumbnail image if available
+            if (gearItem->image.isValid())
+            {
+                juce::Rectangle<int> imageArea = getLocalBounds().reduced(20);
+                g.drawImageWithin(gearItem->image,
+                                  imageArea.getX(), imageArea.getY() + 40,
+                                  imageArea.getWidth(), imageArea.getHeight() - 40,
+                                  juce::RectanglePlacement::centred);
+            }
         }
     }
     else
@@ -120,17 +165,20 @@ void RackSlot::resized()
     // Position the arrow buttons in the top-right corner
     const int buttonSize = 20;
     const int margin = 5;
-    
+
     // Top-right corner, stacked vertically
     upButton->setBounds(getWidth() - buttonSize - margin, margin, buttonSize, buttonSize);
     downButton->setBounds(getWidth() - buttonSize - margin, margin + buttonSize + 2, buttonSize, buttonSize);
 }
 
-void RackSlot::buttonClicked(juce::Button* button)
+void RackSlot::buttonClicked(juce::Button *button)
 {
-    if (button == upButton.get()) {
+    if (button == upButton.get())
+    {
         moveUp();
-    } else if (button == downButton.get()) {
+    }
+    else if (button == downButton.get())
+    {
         moveDown();
     }
 }
@@ -139,185 +187,206 @@ void RackSlot::updateButtonStates()
 {
     // Disable buttons if there's no gear item
     bool hasGear = !isAvailable() && gearItem != nullptr;
-    
+
     // Make sure buttons exist before using them
     if (upButton == nullptr || downButton == nullptr)
         return;
-    
+
     // Up button should be disabled for the first slot
     upButton->setEnabled(hasGear && index > 0);
-    
+
     // Down button should be disabled for the last slot
     // We need to check the total number of slots from the parent Rack
-    Rack* parentRack = dynamic_cast<Rack*>(findParentRackComponent());
-    if (parentRack != nullptr) {
+    Rack *parentRack = dynamic_cast<Rack *>(findParentRackComponent());
+    if (parentRack != nullptr)
+    {
         int totalSlots = parentRack->getNumSlots();
         downButton->setEnabled(hasGear && index < totalSlots - 1);
-    } else {
+    }
+    else
+    {
         downButton->setEnabled(hasGear); // Fallback if we can't get the rack
     }
 }
 
 void RackSlot::moveUp()
 {
-    if (index <= 0 || isAvailable() || gearItem == nullptr) {
+    if (index <= 0 || isAvailable() || gearItem == nullptr)
+    {
         return; // Can't move up if we're the first slot or have no gear
     }
-    
+
     // Find the parent Rack to handle the movement
-    Rack* parentRack = nullptr;
-    juce::Component* parentComponent = findParentRackComponent();
-    
-    if (parentComponent == nullptr) {
+    Rack *parentRack = nullptr;
+    juce::Component *parentComponent = findParentRackComponent();
+
+    if (parentComponent == nullptr)
+    {
         DBG("ERROR: Could not find parent component in moveUp()");
         return;
     }
-    
-    if (parentComponent->getComponentID() == "Rack") {
-        parentRack = dynamic_cast<Rack*>(parentComponent);
-    } else if (parentComponent->getComponentID() == "RackContainer") {
-        auto* container = dynamic_cast<Rack::RackContainer*>(parentComponent);
-        if (container != nullptr && container->rack != nullptr) {
+
+    if (parentComponent->getComponentID() == "Rack")
+    {
+        parentRack = dynamic_cast<Rack *>(parentComponent);
+    }
+    else if (parentComponent->getComponentID() == "RackContainer")
+    {
+        auto *container = dynamic_cast<Rack::RackContainer *>(parentComponent);
+        if (container != nullptr && container->rack != nullptr)
+        {
             parentRack = container->rack;
         }
     }
-    
-    if (parentRack != nullptr) {
+
+    if (parentRack != nullptr)
+    {
         // Move the item up by 1 slot
         parentRack->rearrangeGearAsSortableList(index, index - 1);
-    } else {
+    }
+    else
+    {
         DBG("ERROR: Could not find parent Rack in moveUp()");
     }
 }
 
 void RackSlot::moveDown()
 {
-    if (isAvailable() || gearItem == nullptr) {
+    if (isAvailable() || gearItem == nullptr)
+    {
         return; // Can't move if we have no gear
     }
-    
+
     // Find the parent Rack to handle the movement
-    Rack* parentRack = nullptr;
-    juce::Component* parentComponent = findParentRackComponent();
-    
-    if (parentComponent == nullptr) {
+    Rack *parentRack = nullptr;
+    juce::Component *parentComponent = findParentRackComponent();
+
+    if (parentComponent == nullptr)
+    {
         DBG("ERROR: Could not find parent component in moveDown()");
         return;
     }
-    
-    if (parentComponent->getComponentID() == "Rack") {
-        parentRack = dynamic_cast<Rack*>(parentComponent);
-    } else if (parentComponent->getComponentID() == "RackContainer") {
-        auto* container = dynamic_cast<Rack::RackContainer*>(parentComponent);
-        if (container != nullptr && container->rack != nullptr) {
+
+    if (parentComponent->getComponentID() == "Rack")
+    {
+        parentRack = dynamic_cast<Rack *>(parentComponent);
+    }
+    else if (parentComponent->getComponentID() == "RackContainer")
+    {
+        auto *container = dynamic_cast<Rack::RackContainer *>(parentComponent);
+        if (container != nullptr && container->rack != nullptr)
+        {
             parentRack = container->rack;
         }
     }
-    
-    if (parentRack != nullptr) {
+
+    if (parentRack != nullptr)
+    {
         int totalSlots = parentRack->getNumSlots();
-        if (index < totalSlots - 1) {
+        if (index < totalSlots - 1)
+        {
             // Move the item down by 1 slot
             parentRack->rearrangeGearAsSortableList(index, index + 1);
         }
-    } else {
+    }
+    else
+    {
         DBG("ERROR: Could not find parent Rack in moveDown()");
     }
 }
 
 // Keeping the mouse event handlers but simplifying them to do nothing
-void RackSlot::mouseDown(const juce::MouseEvent& e)
+void RackSlot::mouseDown(const juce::MouseEvent &e)
 {
     // We're now using buttons for navigation instead of drag-and-drop
 }
 
-void RackSlot::mouseDrag(const juce::MouseEvent& e)
+void RackSlot::mouseDrag(const juce::MouseEvent &e)
 {
     // We're now using buttons for navigation instead of drag-and-drop
 }
 
-void RackSlot::mouseUp(const juce::MouseEvent&)
+void RackSlot::mouseUp(const juce::MouseEvent &)
 {
     // We're now using buttons for navigation instead of drag-and-drop
 }
 
 // The rest of the existing implementation follows...
 
-bool RackSlot::isInterestedInDragSource(const juce::DragAndDropTarget::SourceDetails& sourceDetails)
+bool RackSlot::isInterestedInDragSource(const juce::DragAndDropTarget::SourceDetails &sourceDetails)
 {
     // We're not using drag-and-drop for reordering anymore, but keeping the code for GearLibrary drags
-    
+
     // Accept drag sources from the GearLibrary list box (legacy)
     if (sourceDetails.description.isInt())
     {
-        auto* sourceComp = sourceDetails.sourceComponent.get();
-        if (sourceComp && (sourceComp->getComponentID() == "DraggableListBox" || 
+        auto *sourceComp = sourceDetails.sourceComponent.get();
+        if (sourceComp && (sourceComp->getComponentID() == "DraggableListBox" ||
                            sourceComp->getComponentID() == "GearListBox"))
         {
             return true;
         }
     }
-    
+
     // Accept drag sources from TreeView (new hierarchical view)
     if (sourceDetails.description.isString())
     {
         juce::String desc = sourceDetails.description.toString();
         if (desc.startsWith("GEAR:"))
         {
-            auto* sourceComp = sourceDetails.sourceComponent.get();
-            if (sourceComp && dynamic_cast<juce::TreeView*>(sourceComp) != nullptr)
+            auto *sourceComp = sourceDetails.sourceComponent.get();
+            if (sourceComp && dynamic_cast<juce::TreeView *>(sourceComp) != nullptr)
             {
                 return true;
             }
         }
     }
-    
+
     return false;
 }
 
-void RackSlot::itemDragEnter(const juce::DragAndDropTarget::SourceDetails& /*details*/)
+void RackSlot::itemDragEnter(const juce::DragAndDropTarget::SourceDetails & /*details*/)
 {
     setHighlighted(true);
 }
 
-void RackSlot::itemDragMove(const juce::DragAndDropTarget::SourceDetails& /*details*/)
+void RackSlot::itemDragMove(const juce::DragAndDropTarget::SourceDetails & /*details*/)
 {
     // Nothing needed here
 }
 
-void RackSlot::itemDragExit(const juce::DragAndDropTarget::SourceDetails& /*details*/)
+void RackSlot::itemDragExit(const juce::DragAndDropTarget::SourceDetails & /*details*/)
 {
     setHighlighted(false);
 }
 
-void RackSlot::itemDropped(const juce::DragAndDropTarget::SourceDetails& details)
+void RackSlot::itemDropped(const juce::DragAndDropTarget::SourceDetails &details)
 {
     setHighlighted(false);
-    
+
     // Only handle drops from GearLibrary - delegate to parent Rack
-    juce::Component* parentComponent = findParentRackComponent();
-    
+    juce::Component *parentComponent = findParentRackComponent();
+
     if (parentComponent != nullptr)
     {
         // Convert source details to parent's coordinate system
         juce::Point<int> positionInParent;
-        
+
         // Handle case where direct parent is RackContainer or Rack
-        if (parentComponent->getComponentID() == "Rack") 
+        if (parentComponent->getComponentID() == "Rack")
         {
             // Direct parent is the Rack
-            Rack* parentRack = dynamic_cast<Rack*>(parentComponent);
+            Rack *parentRack = dynamic_cast<Rack *>(parentComponent);
             if (parentRack != nullptr)
             {
                 positionInParent = parentRack->getLocalPoint(this, details.localPosition);
-                
+
                 // Create simplified source details with only the required data
                 juce::DragAndDropTarget::SourceDetails parentDetails(
                     details.description,
                     details.sourceComponent.get(),
-                    positionInParent
-                );
-                
+                    positionInParent);
+
                 // Call the parent's itemDropped directly
                 parentRack->itemDropped(parentDetails);
             }
@@ -325,20 +394,19 @@ void RackSlot::itemDropped(const juce::DragAndDropTarget::SourceDetails& details
         else if (parentComponent->getComponentID() == "RackContainer")
         {
             // Parent is RackContainer, need to find its Rack parent
-            auto* container = dynamic_cast<Rack::RackContainer*>(parentComponent);
+            auto *container = dynamic_cast<Rack::RackContainer *>(parentComponent);
             if (container != nullptr && container->rack != nullptr)
             {
                 // Convert twice - first to container, then to rack
                 auto posInContainer = container->getLocalPoint(this, details.localPosition);
                 positionInParent = container->rack->getLocalPoint(container, posInContainer);
-                
+
                 // Create simplified source details with only the required data
                 juce::DragAndDropTarget::SourceDetails parentDetails(
                     details.description,
                     details.sourceComponent.get(),
-                    positionInParent
-                );
-                
+                    positionInParent);
+
                 // Call the Rack's itemDropped
                 container->rack->itemDropped(parentDetails);
             }
@@ -346,12 +414,12 @@ void RackSlot::itemDropped(const juce::DragAndDropTarget::SourceDetails& details
     }
 }
 
-void RackSlot::setGearItem(GearItem* newGearItem)
+void RackSlot::setGearItem(GearItem *newGearItem)
 {
     DBG("RackSlot::setGearItem for slot " + juce::String(index));
     gearItem = newGearItem;
     updateButtonStates(); // Update button states when gear changes
-    repaint(); // Trigger repaint to show the gear item
+    repaint();            // Trigger repaint to show the gear item
 }
 
 void RackSlot::clearGearItem()
@@ -359,7 +427,7 @@ void RackSlot::clearGearItem()
     DBG("RackSlot::clearGearItem for slot " + juce::String(index));
     gearItem = nullptr;
     updateButtonStates(); // Update button states when gear is removed
-    repaint(); // Trigger repaint to update
+    repaint();            // Trigger repaint to update
 }
 
 void RackSlot::setHighlighted(bool shouldHighlight)
@@ -369,9 +437,9 @@ void RackSlot::setHighlighted(bool shouldHighlight)
 }
 
 // New helper method to find parent Rack
-juce::Component* RackSlot::findParentRackComponent()
+juce::Component *RackSlot::findParentRackComponent()
 {
-    juce::Component* parent = getParentComponent();
+    juce::Component *parent = getParentComponent();
     while (parent != nullptr)
     {
         if (parent->getComponentID() == "Rack" || parent->getComponentID() == "RackContainer")
@@ -381,4 +449,4 @@ juce::Component* RackSlot::findParentRackComponent()
         parent = parent->getParentComponent();
     }
     return nullptr;
-} 
+}


### PR DESCRIPTION
- Dropping a unit into the rack now pulls the unit's schema remotely
- Fetch the unit's faceplate from the schema
- Use the faceplate in the rack instead of the thumbnail
- Rack slot height is variable so that it can stretch to the unit's size while maintaining aspect ratio. (units cannot be wider than the current slot width)