### PR TITLE
buttons work, similar to switches, unless momentary

### DIFF
--- a/Source/GearItem.h
+++ b/Source/GearItem.h
@@ -53,12 +53,18 @@ public:
           startAngle(0.0f),
           endAngle(360.0f),
           currentStepIndex(0),
-          length(100)
+          length(100),
+          momentary(false)
     {
     }
 
     GearControl(Type typeParam, const juce::String &nameParam, const juce::Rectangle<float> &positionParam)
-        : type(typeParam), name(nameParam), position(positionParam), value(0.0f), initialValue(0.0f) {}
+        : type(typeParam),
+          name(nameParam),
+          position(positionParam),
+          value(0.0f),
+          initialValue(0.0f),
+          momentary(false) {}
 
     // Add copy constructor
     GearControl(const GearControl &other)
@@ -80,7 +86,10 @@ public:
           switchFrames(other.switchFrames),
           switchSpriteSheet(other.switchSpriteSheet),
           length(other.length),
-          faderImage(other.faderImage)
+          faderImage(other.faderImage),
+          momentary(other.momentary),
+          buttonFrames(other.buttonFrames),
+          buttonSpriteSheet(other.buttonSpriteSheet)
     {
         DBG("GearControl copy constructor called for control: " + name + " with ID: " + id);
     }
@@ -109,6 +118,9 @@ public:
             switchSpriteSheet = other.switchSpriteSheet;
             length = other.length;
             faderImage = other.faderImage;
+            momentary = other.momentary;
+            buttonFrames = other.buttonFrames;
+            buttonSpriteSheet = other.buttonSpriteSheet;
             DBG("GearControl assignment operator called for control: " + name + " with ID: " + id);
         }
         return *this;
@@ -139,6 +151,11 @@ public:
     // Additional properties for faders
     int length = 100;       // Length of the fader track in pixels
     juce::Image faderImage; // The loaded fader image
+
+    // Additional properties for buttons
+    bool momentary = false;                      // Whether the button is momentary or latching
+    juce::Array<SwitchOptionFrame> buttonFrames; // Store frame data for button states
+    juce::Image buttonSpriteSheet;               // The loaded sprite sheet image for buttons
 };
 
 class GearItem

--- a/Source/GearLibrary.h
+++ b/Source/GearLibrary.h
@@ -7,8 +7,9 @@
 // Base URLs and paths for remote resources
 namespace RemoteResources
 {
-    // const juce::String BASE_URL = "https://raw.githubusercontent.com/mazureth/analogiq-schemas/main/";
-    const juce::String BASE_URL = "http://localhost:8000/";
+    const juce::String BASE_URL = "https://raw.githubusercontent.com/mazureth/analogiq-schemas/main/";
+    // for use when making changes to the schemas locally
+    // const juce::String BASE_URL = "http://localhost:8000/";
     const juce::String LIBRARY_PATH = "units/index.json";
     const juce::String ASSETS_PATH = "assets/";
     const juce::String SCHEMAS_PATH = "units/";

--- a/Source/Rack.h
+++ b/Source/Rack.h
@@ -44,6 +44,7 @@ public:
     void fetchKnobImage(GearItem *item, int controlIndex);
     void fetchFaderImage(GearItem *item, int controlIndex);
     void fetchSwitchSpriteSheet(GearItem *item, int controlIndex);
+    void fetchButtonSpriteSheet(GearItem *item, int controlIndex);
 
     // Instance management
     void createInstance(int slotIndex);


### PR DESCRIPTION
- buttons run on sprites
- momentary buttons should only have 2 states, off (index 0) and on (index 1) and should return to off on mouseUp
- other buttons cycle through all options and latch to current options. 
- while most buttons may only have 2 latched states, there is an option for N states (consider the mutli-state buttons on a Distressor for example)