### PR TITLE
making the mouse hit areas the same size as the controls themselves

### DIFF
--- a/Source/GearLibrary.h
+++ b/Source/GearLibrary.h
@@ -19,9 +19,9 @@
  */
 namespace RemoteResources
 {
-    const juce::String BASE_URL = "https://raw.githubusercontent.com/mazureth/analogiq-schemas/main/";
+    // const juce::String BASE_URL = "https://raw.githubusercontent.com/mazureth/analogiq-schemas/main/";
     // for use when making changes to the schemas locally
-    // const juce::String BASE_URL = "http://localhost:8000/";
+    const juce::String BASE_URL = "http://localhost:8000/";
     const juce::String LIBRARY_PATH = "units/index.json";
     const juce::String ASSETS_PATH = "assets/";
     const juce::String SCHEMAS_PATH = "units/";


### PR DESCRIPTION
- check control image's scaled size
- paint the mouse hit area to be the entire image
- also works for sprites