### PR TITLE
create release artifacts 

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,0 +1,132 @@
+name: Build and Release Plugin
+
+on:
+  push:
+    tags:
+      - 'v*'  # Trigger on version tags like v1.0.0, v2.1.3, etc.
+  workflow_dispatch:  # Allow manual triggering
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    name: Build for macOS
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Dependencies
+        run: |
+          brew install cmake
+
+      - name: Configure and Build
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=Release \
+            -DANALOGIQ_BUILD_AAX=ON \
+            -DANALOGIQ_BUILD_VST3=ON \
+            -DANALOGIQ_BUILD_AU=ON \
+            -DANALOGIQ_BUILD_STANDALONE=ON \
+            -DANALOGIQ_BUILD_TESTS=OFF \
+            -DANALOGIQ_COPY_PLUGINS=ON
+          cmake --build build --config Release --parallel
+
+      - name: Find Plugin Files
+        id: find-plugins
+        run: |
+          echo "vst3_files=$(find build -name "*.vst3" -type d)" >> $GITHUB_OUTPUT
+          echo "au_files=$(find build -name "*.component" -type d)" >> $GITHUB_OUTPUT
+          echo "aax_files=$(find build -name "*.aaxplugin" -type d)" >> $GITHUB_OUTPUT
+          echo "standalone_files=$(find build -name "AnalogIQ" -type f -perm +111)" >> $GITHUB_OUTPUT
+
+      - name: Create macOS Release Package
+        run: |
+          mkdir -p release/macos
+          
+          # Copy VST3 plugins
+          if [ -d "build/AnalogIQ_artefacts/Release/VST3" ]; then
+            cp -R build/AnalogIQ_artefacts/Release/VST3 release/macos/
+          fi
+          
+          # Copy AU plugins
+          if [ -d "build/AnalogIQ_artefacts/Release/AU" ]; then
+            cp -R build/AnalogIQ_artefacts/Release/AU release/macos/
+          fi
+          
+          # Copy AAX plugins
+          if [ -d "build/AnalogIQ_artefacts/Release/AAX" ]; then
+            cp -R build/AnalogIQ_artefacts/Release/AAX release/macos/
+          fi
+          
+          # Copy Standalone app
+          if [ -f "build/AnalogIQ_artefacts/Release/Standalone/AnalogIQ.app/Contents/MacOS/AnalogIQ" ]; then
+            cp -R build/AnalogIQ_artefacts/Release/Standalone/AnalogIQ.app release/macos/
+          fi
+          
+          # Create zip archive
+          cd release
+          zip -r AnalogIQ-macos-${GITHUB_REF_NAME}.zip macos/
+          cd ..
+
+      - name: Upload macOS Release Assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: AnalogIQ-macos-${{ github.ref_name }}
+          path: release/AnalogIQ-macos-${{ github.ref_name }}.zip
+
+  build-windows:
+    runs-on: windows-latest
+    name: Build for Windows
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Dependencies
+        run: |
+          # Install Visual Studio Build Tools
+          # These are pre-installed on windows-latest
+
+      - name: Configure and Build
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=Release \
+            -DANALOGIQ_BUILD_AAX=ON \
+            -DANALOGIQ_BUILD_VST3=ON \
+            -DANALOGIQ_BUILD_AU=OFF \
+            -DANALOGIQ_BUILD_STANDALONE=ON \
+            -DANALOGIQ_BUILD_TESTS=OFF \
+            -DANALOGIQ_COPY_PLUGINS=ON
+          cmake --build build --config Release --parallel
+
+      - name: Create Windows Release Package
+        run: |
+          mkdir -p release/windows
+          
+          # Copy VST3 plugins
+          if (Test-Path "build/AnalogIQ_artefacts/Release/VST3") {
+            Copy-Item -Recurse "build/AnalogIQ_artefacts/Release/VST3" "release/windows/"
+          }
+          
+          # Copy AAX plugins
+          if (Test-Path "build/AnalogIQ_artefacts/Release/AAX") {
+            Copy-Item -Recurse "build/AnalogIQ_artefacts/Release/AAX" "release/windows/"
+          }
+          
+          # Copy Standalone executable
+          if (Test-Path "build/AnalogIQ_artefacts/Release/Standalone/AnalogIQ.exe") {
+            Copy-Item -Recurse "build/AnalogIQ_artefacts/Release/Standalone" "release/windows/"
+          }
+          
+          # Create zip archive
+          cd release
+          Compress-Archive -Path "windows/*" -DestinationPath "AnalogIQ-windows-${{ github.ref_name }}.zip"
+          cd ..
+
+      - name: Upload Windows Release Assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: AnalogIQ-windows-${{ github.ref_name }}
+          path: release/AnalogIQ-windows-${{ github.ref_name }}.zip

--- a/README.md
+++ b/README.md
@@ -156,3 +156,50 @@ The preset system allows you to save and load complete rack configurations:
   - `AnalogIQProcessor.*` - Core plugin functionality
   - `AnalogIQEditor.*` - Main UI components
   - `GearLibrary.*` - Gear browser and library management
+
+## Automated Releases
+
+This project uses GitHub Actions to automatically build and release the plugin when a new version tag is pushed.
+
+### Creating a Release
+
+1. **Update the version** in `CMakeLists.txt` (optional - will be auto-updated):
+   ```bash
+   # Edit CMakeLists.txt and change the VERSION line
+   project(AnalogIQ VERSION 1.0.0)
+   ```
+
+2. **Create and push a new tag**:
+   ```bash
+   git tag -a v1.0.0 -m "[some message]"
+   git push origin v1.0.0
+   ```
+
+3. **The GitHub Action will automatically**:
+   - Update the version in `CMakeLists.txt` to match the tag
+   - Build the plugin for both macOS and Windows
+   - Create a GitHub release with downloadable packages
+   - Include all plugin formats (VST3, AAX, AU, Standalone)
+
+### Release Artifacts
+
+Each release includes:
+- **AnalogIQ-macos-v1.0.0.zip** - macOS package with VST3, AU, AAX, and Standalone
+- **AnalogIQ-windows-v1.0.0.zip** - Windows package with VST3, AAX, and Standalone
+
+### Supported Plugin Formats
+
+- **VST3**: Compatible with most modern DAWs (Cubase, Reaper, etc.)
+- **AAX**: Pro Tools compatibility
+- **Audio Unit (AU)**: Native macOS plugin format
+- **Standalone**: Run without a DAW
+
+### Build Configuration
+
+The automated builds use the following CMake options:
+- `ANALOGIQ_BUILD_AAX=ON` - Build AAX plugins
+- `ANALOGIQ_BUILD_VST3=ON` - Build VST3 plugins  
+- `ANALOGIQ_BUILD_AU=ON` (macOS only) - Build Audio Unit plugins
+- `ANALOGIQ_BUILD_STANDALONE=ON` - Build standalone application
+- `ANALOGIQ_BUILD_TESTS=OFF` - Skip tests for faster builds
+- `ANALOGIQ_COPY_PLUGINS=ON` - Copy plugins to artifacts directory


### PR DESCRIPTION
Whenever the tag is updated, we can assume there has been some changes to the plugin and we should automatically build the necessary output artifacts for distribution. 