### PR TITLE
fix for instance persistence

### DIFF
--- a/Source/GearLibrary.cpp
+++ b/Source/GearLibrary.cpp
@@ -1307,6 +1307,23 @@ GearItem *GearLibrary::getGearItem(int index)
 }
 
 /**
+ * @brief Gets a gear item by unit ID.
+ *
+ * @param unitId The unit ID of the gear item to retrieve
+ * @return Pointer to the gear item, or nullptr if not found
+ */
+GearItem *GearLibrary::getGearItemByUnitId(const juce::String &unitId)
+{
+    for (auto &item : gearItems)
+    {
+        if (item.unitId == unitId)
+            return &item;
+    }
+
+    return nullptr;
+}
+
+/**
  * @brief Handles mouse down events.
  *
  * @param e The mouse event details

--- a/Source/GearLibrary.h
+++ b/Source/GearLibrary.h
@@ -147,6 +147,14 @@ public:
     GearItem *getGearItem(int index);
 
     /**
+     * @brief Gets a gear item by unit ID.
+     *
+     * @param unitId The unit ID of the gear item to retrieve
+     * @return Pointer to the gear item, or nullptr if not found
+     */
+    GearItem *getGearItemByUnitId(const juce::String &unitId);
+
+    /**
      * @brief Gets the full array of gear items.
      *
      * @return Constant reference to the array of gear items


### PR DESCRIPTION
JUCE's default instance state management is only for simple, flat data. Our plugin extends that with a more complex state management method but out method was being explicitly called from the default method so instances were not persisting in an actual DAW. This fixes that bug.